### PR TITLE
Fix using SDCV_PAGER

### DIFF
--- a/src/libwrapper.cpp
+++ b/src/libwrapper.cpp
@@ -288,7 +288,7 @@ namespace {
         sdcv_pager& operator=(const sdcv_pager&) = delete;
         ~sdcv_pager() {
             if (output != stdout)
-                fclose(output);
+                pclose(output);
         }
         FILE *get_stream() { return output; }
     private:


### PR DESCRIPTION
Stream opened with popen() should be closed with pclose() as documented
in popen(3) man.

At least on FreeBSD SDCV_PAGER wasn't usable, because fclose() doesn't wait for child process (pager) and after termination of sdcv less/more also is terminated. Difference probably not between Linux/BSD, but between different implementations of fclose() in glibc and BSD libc or in llvm libc++ and GNU Standard C++ Library. Anyway pclose() should be used here.