### PR TITLE
Pass parameters individually to the test

### DIFF
--- a/tests/t_json
+++ b/tests/t_json
@@ -9,17 +9,17 @@ unset SDCV_PAGER
 unset STARDICT_DATA_DIR
 
 test_json() {
-    PARAMS="$1"
-    EXPECTED=$(echo "$2" | jq 'sort')
-    RESULT=$($SDCV $PARAMS | jq 'sort')
+    EXPECTED=$(echo "$1" | jq 'sort')
+    shift
+    RESULT=$($SDCV "$@" | jq 'sort')
     if [ "$EXPECTED" != "$RESULT" ]; then
         echo "expected $EXPECTED but got $RESULT"
         exit 1
     fi
 }
 
-test_json "-x -j -l -n --data-dir $TEST_DIR" "[{\"name\": \"Test synonyms\", \"wordcount\": \"2\"},{\"name\": \"Sample 1 test dictionary\", \"wordcount\": \"1\"},{\"name\": \"test_dict\", \"wordcount\": \"1\"}]"
-test_json "-x -j -n --data-dir $TEST_DIR foo" "[{\"dict\": \"Test synonyms\",\"word\":\"test\",\"definition\":\"\\\nresult of test\"}]"
-test_json "-x -j -n --data-dir $TEST_DIR foobarbaaz" "[]"
+test_json "[{\"name\": \"Test synonyms\", \"wordcount\": \"2\"},{\"name\": \"Sample 1 test dictionary\", \"wordcount\": \"1\"},{\"name\": \"test_dict\", \"wordcount\": \"1\"}]" -x -j -l -n --data-dir "$TEST_DIR"
+test_json "[{\"dict\": \"Test synonyms\",\"word\":\"test\",\"definition\":\"\\\nresult of test\"}]" -x -j -n --data-dir "$TEST_DIR" foo
+test_json "[]" -x -j -n --data-dir "$TEST_DIR" foobarbaaz
 
 exit 0


### PR DESCRIPTION
This way we can properly quote path.

This is probably better approach than just removing the quotes as done in #34.