### PR TITLE
Use single quotes around JSON data to reduce need for escaping

### DIFF
--- a/tests/t_json
+++ b/tests/t_json
@@ -18,8 +18,8 @@ test_json() {
     fi
 }
 
-test_json "[{\"name\": \"Test synonyms\", \"wordcount\": \"2\"},{\"name\": \"Sample 1 test dictionary\", \"wordcount\": \"1\"},{\"name\": \"test_dict\", \"wordcount\": \"1\"}]" -x -j -l -n --data-dir "$TEST_DIR"
-test_json "[{\"dict\": \"Test synonyms\",\"word\":\"test\",\"definition\":\"\\\nresult of test\"}]" -x -j -n --data-dir "$TEST_DIR" foo
-test_json "[]" -x -j -n --data-dir "$TEST_DIR" foobarbaaz
+test_json '[{"name": "Test synonyms", "wordcount": "2"},{"name": "Sample 1 test dictionary", "wordcount": "1"},{"name": "test_dict", "wordcount": "1"}]' -x -j -l -n --data-dir "$TEST_DIR"
+test_json '[{"dict": "Test synonyms","word":"test","definition":"\u000aresult of test"}]' -x -j -n --data-dir "$TEST_DIR" foo
+test_json '[]' -x -j -n --data-dir "$TEST_DIR" foobarbaaz
 
 exit 0


### PR DESCRIPTION
Also use unicode escape sequence for newline to avoid problems with some
shells decoding \n even when they probably should not.