### PR TITLE
Added `$SDCV_HISTFILE` to set history file

### DIFF
--- a/doc/sdcv.1
+++ b/doc/sdcv.1
@@ -89,8 +89,11 @@ If set, sdcv uses this variable as the data directory, this means that sdcv
 searches dictionaries in $\fBSTARDICT_DATA_DIR\fR\\dic
 .TP 20
 .B SDCV_HISTSIZE
-If set, sdcv writes in $(HOME)/.sdcv_history the last $(SDCV_HISTSIZE) words, 
+If set, sdcv writes in $(HOME)/.sdcv_history (or $(SDCV_HISTFILE)) the last $(SDCV_HISTSIZE) words, 
 which you look up using sdcv. If it is not set, then the last 2000 words are saved in $(HOME)/.sdcv_history.
+.TP 20
+.B SDCV_HISTFILE
+If set, sdcv writes it's history to $(SDCV_HISTFILE). If it is not set, then the default $(HOME)/.sdcv_history path will be used.
 .TP 20
 .B SDCV_PAGER
 If SDCV_PAGER is set, its value is used as the name of the program

--- a/src/readline.cpp
+++ b/src/readline.cpp
@@ -70,13 +70,15 @@ public:
     {
         rl_readline_name = "sdcv";
         using_history();
-        const std::string histname = std::string(g_get_home_dir()) + G_DIR_SEPARATOR + ".sdcv_history";
+        const gchar *hist_file_str = g_getenv("SDCV_HISTFILE");
+        const std::string histname = hist_file_str ? std::string(hist_file_str) : (std::string(g_get_home_dir()) + G_DIR_SEPARATOR + ".sdcv_history");
         read_history(histname.c_str());
     }
 
     ~real_readline()
     {
-        const std::string histname = std::string(g_get_home_dir()) + G_DIR_SEPARATOR + ".sdcv_history";
+        const gchar *hist_file_str = g_getenv("SDCV_HISTFILE");
+        const std::string histname = hist_file_str ? std::string(hist_file_str) : (std::string(g_get_home_dir()) + G_DIR_SEPARATOR + ".sdcv_history");
         write_history(histname.c_str());
         const gchar *hist_size_str = g_getenv("SDCV_HISTSIZE");
         int hist_size;


### PR DESCRIPTION
sdcv will check if `$SDCV_HISTFILE` is set and use that as the history file, otherwise it will use the default `"${HOME}/.sdcv_history"`.

Fixes #15 
