### PR TITLE
Use binary search for synonyms, fixes #31

### DIFF
--- a/src/stardict_lib.cpp
+++ b/src/stardict_lib.cpp
@@ -831,19 +831,14 @@ bool WordListIndex::lookup(const char *str, glong &idx)
 
 bool SynFile::load(const std::string &url, gulong wc)
 {
-
     struct stat stat_buf;
     if (!stat(url.c_str(), &stat_buf)) {
 
-        MapFile syn;
-        if (!syn.open(url.c_str(), stat_buf.st_size))
+        if (!synfile.open(url.c_str(), stat_buf.st_size))
             return false;
 
-        syndatabuf = (gchar *)g_malloc(stat_buf.st_size);
-        memcpy(syndatabuf, syn.begin(),  stat_buf.st_size);
-
         synlist.resize(wc + 1);
-        gchar *p1 = syndatabuf;
+        gchar *p1 = synfile.begin();
 
         for (unsigned long i = 0; i < wc; i++) {
             // each entry in a syn-file is:

--- a/src/stardict_lib.cpp
+++ b/src/stardict_lib.cpp
@@ -897,8 +897,10 @@ bool SynFile::lookup(const char *str, glong &idx)
         }
         if (!bFound)
             idx = iFrom; //next
-        else
-            idx = iThisIndex;
+        else {
+            const gchar *key = get_key(iThisIndex);
+            idx = g_ntohl(get_uint32(key+strlen(key)+1));
+        }
     }
     return bFound;
 }

--- a/src/stardict_lib.cpp
+++ b/src/stardict_lib.cpp
@@ -874,6 +874,7 @@ bool SynFile::lookup(const char *str, glong &idx)
 {
     bool bFound = false;
     glong iTo = synlist.size() - 2;
+    if (iTo <0) return false;
 
     if (stardict_strcmp(str, get_key(0)) < 0) {
         idx = 0;

--- a/src/stardict_lib.cpp
+++ b/src/stardict_lib.cpp
@@ -831,25 +831,16 @@ bool WordListIndex::lookup(const char *str, glong &idx)
 
 bool SynFile::load(const std::string &url, gulong wc)
 {
+
     struct stat stat_buf;
     if (!stat(url.c_str(), &stat_buf)) {
 
-        FILE *in = fopen(url.c_str(), "rb");
-        if (!in)
+        MapFile syn;
+        if (!syn.open(url.c_str(), stat_buf.st_size))
             return false;
 
-        fseek(in, 0, SEEK_END);
-        gulong fsize = ftell(in);
-        fseek(in, 0, SEEK_SET);
-        syndatabuf = (gchar *)g_malloc(fsize);
-
-        const int len = fread(syndatabuf, 1, fsize, in);
-        fclose(in);
-        if (len < 0)
-            return false;
-
-        if (gulong(len) != fsize)
-            return false;
+        syndatabuf = (gchar *)g_malloc(stat_buf.st_size);
+        memcpy(syndatabuf, syn.begin(),  stat_buf.st_size);
 
         synlist.resize(wc + 1);
         gchar *p1 = syndatabuf;

--- a/src/stardict_lib.hpp
+++ b/src/stardict_lib.hpp
@@ -102,11 +102,18 @@ public:
 class SynFile
 {
 public:
+    SynFile()
+        : syndatabuf(nullptr)
+    {
+    }
+    ~SynFile() { g_free(syndatabuf); }
     bool load(const std::string &url, gulong wc);
     bool lookup(const char *str, glong &idx);
+    const gchar *get_key(glong idx) { return synlist[idx]; }
 
 private:
-    std::map<std::string, gulong> synonyms;
+    gchar *syndatabuf;
+    std::vector<gchar *> synlist;
 };
 
 class Dict : public DictBase

--- a/src/stardict_lib.hpp
+++ b/src/stardict_lib.hpp
@@ -102,17 +102,14 @@ public:
 class SynFile
 {
 public:
-    SynFile()
-        : syndatabuf(nullptr)
-    {
-    }
-    ~SynFile() { g_free(syndatabuf); }
+    SynFile() {}
+    ~SynFile() {}
     bool load(const std::string &url, gulong wc);
     bool lookup(const char *str, glong &idx);
     const gchar *get_key(glong idx) { return synlist[idx]; }
 
 private:
-    gchar *syndatabuf;
+    MapFile synfile;
     std::vector<gchar *> synlist;
 };
 


### PR DESCRIPTION
This replaces the SynFile::load and SynFile::search with logic borrowed from WordListIndex, resulting in dramatic speed improvement on dictionaries with large synonyms.

Before:
```
$ time ./sdcv -2 dicts/ hola
Found 1 items, similar to hola.
-->Wiktionary (es-en)
-->hola

hola (interj)
1. hello, hi

real    0m8.084s
user    0m7.979s
sys     0m0.090s
```

After
```
Found 1 items, similar to hola.
-->Wiktionary (es-en)
-->hola

hola (interj)
1. hello, hi


real    0m0.095s
user    0m0.039s
sys     0m0.042s
```