### PR TITLE
Handle "rest" arguments the glib way

### DIFF
--- a/src/libwrapper.cpp
+++ b/src/libwrapper.cpp
@@ -332,17 +332,10 @@ search_result Library::process_phrase(const char *loc_str, IReadLine &io, bool f
     glib::Error err;
     search_result rval = SEARCH_SUCCESS;
     glib::CharStr str;
-    // Glib already runs CLI arguments through g_locale_to_utf8
-    if (g_get_charset(nullptr)) {
-        // Current locale is UTF-8
+    if (!utf8_input_)
+        str.reset(g_locale_to_utf8(loc_str, -1, &bytes_read, &bytes_written, get_addr(err)));
+    else
         str.reset(g_strdup(loc_str));
-    } else {
-        if (!utf8_input_) {
-            str.reset(g_strdup(loc_str));
-        } else {
-            str.reset(g_locale_from_utf8(loc_str, -1, &bytes_read, &bytes_written, get_addr(err)));
-        }
-    }
 
     if (nullptr == get_impl(str)) {
         fprintf(stderr, _("Can not convert %s to utf8.\n"), loc_str);

--- a/src/libwrapper.cpp
+++ b/src/libwrapper.cpp
@@ -332,10 +332,17 @@ search_result Library::process_phrase(const char *loc_str, IReadLine &io, bool f
     glib::Error err;
     search_result rval = SEARCH_SUCCESS;
     glib::CharStr str;
-    if (!utf8_input_)
-        str.reset(g_locale_to_utf8(loc_str, -1, &bytes_read, &bytes_written, get_addr(err)));
-    else
+    // Glib already runs CLI arguments through g_locale_to_utf8
+    if (g_get_charset(nullptr)) {
+        // Current locale is UTF-8
         str.reset(g_strdup(loc_str));
+    } else {
+        if (!utf8_input_) {
+            str.reset(g_strdup(loc_str));
+        } else {
+            str.reset(g_locale_from_utf8(loc_str, -1, &bytes_read, &bytes_written, get_addr(err)));
+        }
+    }
 
     if (nullptr == get_impl(str)) {
         fprintf(stderr, _("Can not convert %s to utf8.\n"), loc_str);

--- a/src/sdcv.cpp
+++ b/src/sdcv.cpp
@@ -83,6 +83,7 @@ try {
     glib::CharStr opt_data_dir;
     gboolean only_data_dir = FALSE;
     gboolean colorize = FALSE;
+    glib::StrArr word_list;
 
     const GOptionEntry entries[] = {
         { "version", 'v', 0, G_OPTION_ARG_NONE, &show_version,
@@ -109,11 +110,13 @@ try {
           _("only use the dictionaries in data-dir, do not search in user and system directories"), nullptr },
         { "color", 'c', 0, G_OPTION_ARG_NONE, &colorize,
           _("colorize the output"), nullptr },
+        { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, get_addr(word_list),
+          _("search terms"), _(" words") },
         {},
     };
 
     glib::Error error;
-    GOptionContext *context = g_option_context_new(_(" words"));
+    GOptionContext *context = g_option_context_new(nullptr);
     g_option_context_set_help_enabled(context, TRUE);
     g_option_context_add_main_entries(context, entries, nullptr);
     const gboolean parse_res = g_option_context_parse(context, &argc, &argv, get_addr(error));
@@ -210,12 +213,14 @@ try {
     lib.load(dicts_dir_list, order_list, disable_list);
 
     std::unique_ptr<IReadLine> io(create_readline_object());
-    if (optind < argc) {
+    if (word_list != nullptr) {
         search_result rval = SEARCH_SUCCESS;
-        for (int i = optind; i < argc; ++i)
-            if ((rval = lib.process_phrase(argv[i], *io, non_interactive)) != SEARCH_SUCCESS) {
+        gchar **p = get_impl(word_list);
+        while (*p) {
+            if ((rval = lib.process_phrase(*p++, *io, non_interactive)) != SEARCH_SUCCESS) {
                 return rval;
             }
+        }
     } else if (!non_interactive) {
 
         std::string phrase;

--- a/src/sdcv.cpp
+++ b/src/sdcv.cpp
@@ -83,6 +83,7 @@ try {
     glib::CharStr opt_data_dir;
     gboolean only_data_dir = FALSE;
     gboolean colorize = FALSE;
+    glib::StrArr word_list;
 
     const GOptionEntry entries[] = {
         { "version", 'v', 0, G_OPTION_ARG_NONE, &show_version,
@@ -109,11 +110,13 @@ try {
           _("only use the dictionaries in data-dir, do not search in user and system directories"), nullptr },
         { "color", 'c', 0, G_OPTION_ARG_NONE, &colorize,
           _("colorize the output"), nullptr },
+        { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, get_addr(word_list),
+          _("search terms"), _(" words") },
         {},
     };
 
     glib::Error error;
-    GOptionContext *context = g_option_context_new(_(" words"));
+    GOptionContext *context = g_option_context_new(nullptr);
     g_option_context_set_help_enabled(context, TRUE);
     g_option_context_add_main_entries(context, entries, nullptr);
     const gboolean parse_res = g_option_context_parse(context, &argc, &argv, get_addr(error));
@@ -210,14 +213,11 @@ try {
     lib.load(dicts_dir_list, order_list, disable_list);
 
     std::unique_ptr<IReadLine> io(create_readline_object());
-    if (argc > 1) {
+    if (word_list != nullptr) {
         search_result rval = SEARCH_SUCCESS;
-        for (int i = 1; i < argc; i++) {
-            // Skip the GNU "stop option parsing" token ("--"), because glib won't do it for us without G_OPTION_REMAINING
-            if (strcmp(argv[i], "--") == 0) {
-                continue;
-            }
-            if ((rval = lib.process_phrase(argv[i], *io, non_interactive)) != SEARCH_SUCCESS) {
+        gchar **p = get_impl(word_list);
+        while (*p) {
+            if ((rval = lib.process_phrase(*p++, *io, non_interactive)) != SEARCH_SUCCESS) {
                 return rval;
             }
         }


### PR DESCRIPTION
Ensures the "stop parsing" token `--` is handled properly, without having to resort to [more hackery](https://github.com/koreader/koreader/pull/7134#issuecomment-758069472).