### PR TITLE
Check accesses to the bookname_to_ifo std::map

### DIFF
--- a/src/sdcv.cpp
+++ b/src/sdcv.cpp
@@ -186,10 +186,11 @@ try {
         }
 
         // add bookname to list
-        gchar **p = get_impl(use_dict_list);
-        while (*p) {
-            order_list.push_back(bookname_to_ifo.at(*p));
-            ++p;
+        for (gchar **p = get_impl(use_dict_list); *p != nullptr; ++p) {
+            auto it = bookname_to_ifo.find(*p);
+            if (it != bookname_to_ifo.end()) {
+                order_list.push_back(it->second);
+            }
         }
     } else {
         std::string ordering_cfg_file = std::string(g_get_user_config_dir()) + G_DIR_SEPARATOR_S "sdcv_ordering";
@@ -201,7 +202,10 @@ try {
         if (ordering_file != nullptr) {
             std::string line;
             while (stdio_getline(ordering_file, line)) {
-                order_list.push_back(bookname_to_ifo.at(line));
+                auto it = bookname_to_ifo.find(line);
+                if (it != bookname_to_ifo.end()) {
+                    order_list.push_back(it->second);
+                }
             }
             fclose(ordering_file);
         }

--- a/src/sdcv.cpp
+++ b/src/sdcv.cpp
@@ -190,6 +190,8 @@ try {
             auto it = bookname_to_ifo.find(*p);
             if (it != bookname_to_ifo.end()) {
                 order_list.push_back(it->second);
+            } else {
+                fprintf(stderr, _("Unknown dictionary: %s\n"), *p);
             }
         }
     } else {
@@ -205,6 +207,8 @@ try {
                 auto it = bookname_to_ifo.find(line);
                 if (it != bookname_to_ifo.end()) {
                     order_list.push_back(it->second);
+                } else {
+                    fprintf(stderr, _("Unknown dictionary: %s\n"), line.c_str());
                 }
             }
             fclose(ordering_file);


### PR DESCRIPTION
Avoid crashes when passing unknown dicts to the -u flag

Fix #87