### PR TITLE
Use off_t for stuff mainly assigned to a stat.st_size value

### DIFF
--- a/src/dictziplib.hpp
+++ b/src/dictziplib.hpp
@@ -27,7 +27,7 @@ public:
 private:
     const char *start; /* start of mmap'd area */
     const char *end; /* end of mmap'd area */
-    unsigned long size; /* size of mmap */
+    off_t size; /* size of mmap */
 
     int type;
     z_stream zStream;
@@ -47,7 +47,7 @@ private:
     std::string origFilename;
     std::string comment;
     unsigned long crc;
-    unsigned long length;
+    off_t length;
     unsigned long compressedLength;
     DictCache cache[DICT_CACHE_SIZE];
     MapFile mapfile;

--- a/src/stardict_lib.cpp
+++ b/src/stardict_lib.cpp
@@ -429,7 +429,7 @@ public:
         if (idxfile)
             fclose(idxfile);
     }
-    bool load(const std::string &url, gulong wc, gulong fsize, bool verbose) override;
+    bool load(const std::string &url, gulong wc, off_t fsize, bool verbose) override;
     const gchar *get_key(glong idx) override;
     void get_data(glong idx) override { get_key(idx); }
     const gchar *get_key_and_data(glong idx) override
@@ -489,7 +489,7 @@ public:
     {
     }
     ~WordListIndex() { g_free(idxdatabuf); }
-    bool load(const std::string &url, gulong wc, gulong fsize, bool verbose) override;
+    bool load(const std::string &url, gulong wc, off_t fsize, bool verbose) override;
     const gchar *get_key(glong idx) override { return wordlist[idx]; }
     void get_data(glong idx) override;
     const gchar *get_key_and_data(glong idx) override
@@ -615,7 +615,7 @@ bool OffsetIndex::save_cache(const std::string &url, bool verbose)
     return false;
 }
 
-bool OffsetIndex::load(const std::string &url, gulong wc, gulong fsize, bool verbose)
+bool OffsetIndex::load(const std::string &url, gulong wc, off_t fsize, bool verbose)
 {
     wordcount = wc;
     gulong npages = (wc - 1) / ENTR_PER_PAGE + 2;
@@ -758,7 +758,7 @@ bool OffsetIndex::lookup(const char *str, std::set<glong> &idxs, glong &next_idx
     return bFound;
 }
 
-bool WordListIndex::load(const std::string &url, gulong wc, gulong fsize, bool)
+bool WordListIndex::load(const std::string &url, gulong wc, off_t fsize, bool)
 {
     gzFile in = gzopen(url.c_str(), "rb");
     if (in == nullptr)
@@ -771,7 +771,7 @@ bool WordListIndex::load(const std::string &url, gulong wc, gulong fsize, bool)
     if (len < 0)
         return false;
 
-    if (gulong(len) != fsize)
+    if (static_cast<off_t>(len) != fsize)
         return false;
 
     wordlist.resize(wc + 1);
@@ -920,7 +920,7 @@ bool Dict::Lookup(const char *str, std::set<glong> &idxs, glong &next_idx)
 
 bool Dict::load(const std::string &ifofilename, bool verbose)
 {
-    gulong idxfilesize;
+    off_t idxfilesize;
     if (!load_ifofile(ifofilename, idxfilesize))
         return false;
 
@@ -964,7 +964,7 @@ bool Dict::load(const std::string &ifofilename, bool verbose)
     return true;
 }
 
-bool Dict::load_ifofile(const std::string &ifofilename, gulong &idxfilesize)
+bool Dict::load_ifofile(const std::string &ifofilename, off_t &idxfilesize)
 {
     DictInfo dict_info;
     if (!dict_info.load_from_ifo_file(ifofilename, false))

--- a/src/stardict_lib.hpp
+++ b/src/stardict_lib.hpp
@@ -77,8 +77,8 @@ struct DictInfo {
     std::string website;
     std::string date;
     std::string description;
-    guint32 index_file_size;
-    guint32 syn_file_size;
+    off_t index_file_size;
+    off_t syn_file_size;
     std::string sametypesequence;
 
     bool load_from_ifo_file(const std::string &ifofilename, bool istreedict);
@@ -91,7 +91,7 @@ public:
     guint32 wordentry_size;
 
     virtual ~IIndexFile() {}
-    virtual bool load(const std::string &url, gulong wc, gulong fsize, bool verbose) = 0;
+    virtual bool load(const std::string &url, gulong wc, off_t fsize, bool verbose) = 0;
     virtual const gchar *get_key(glong idx) = 0;
     virtual void get_data(glong idx) = 0;
     virtual const gchar *get_key_and_data(glong idx) = 0;
@@ -160,7 +160,7 @@ private:
     std::unique_ptr<IIndexFile> idx_file;
     std::unique_ptr<SynFile> syn_file;
 
-    bool load_ifofile(const std::string &ifofilename, gulong &idxfilesize);
+    bool load_ifofile(const std::string &ifofilename, off_t &idxfilesize);
 };
 
 class Libs


### PR DESCRIPTION
Allows simplifying the mmap sanity checks in mapfile, and actually ensuring they won't break when -D_FILE_OFFSET_BITS=64

This *possibly* fixes the test failures seen in #86