### PR TITLE
stardict_lib.cpp: use explicit const_cast

### DIFF
--- a/src/stardict_lib.cpp
+++ b/src/stardict_lib.cpp
@@ -1047,7 +1047,7 @@ bool Libs::LookupSimilarWord(const gchar *sWord, std::set<glong> &iWordIndices, 
         }
         // Upper the first character and lower others.
         if (!bFound) {
-            gchar *nextchar = g_utf8_next_char(sWord);
+            gchar *nextchar = const_cast<gchar*>(g_utf8_next_char(sWord));
             gchar *firstchar = g_utf8_strup(sWord, nextchar - sWord);
             nextchar = g_utf8_strdown(nextchar, -1);
             casestr = g_strdup_printf("%s%s", firstchar, nextchar);


### PR DESCRIPTION
Gcc-14 considers incompatible pointer types as an error, so use expcilict const_cast to convert from const char* to gchar*.

This should be a proper fix for #103 .