### PR TITLE
Fix build with GCC 14 and modern glib: const correctness and deprecat…

### DIFF
--- a/src/stardict_lib.cpp
+++ b/src/stardict_lib.cpp
@@ -989,7 +989,7 @@ bool Dict::LookupWithRule(GPatternSpec *pspec, glong *aIndex, int iBuffLen)
     int iIndexCount = 0;
 
     for (guint32 i = 0; i < narticles() && iIndexCount < (iBuffLen - 1); i++)
-        if (g_pattern_match_string(pspec, get_key(i)))
+        if (g_pattern_spec_match_string(pspec, get_key(i)))
             aIndex[iIndexCount++] = i;
 
     aIndex[iIndexCount] = -1; // -1 is the end.
@@ -1047,12 +1047,11 @@ bool Libs::LookupSimilarWord(const gchar *sWord, std::set<glong> &iWordIndices, 
         }
         // Upper the first character and lower others.
         if (!bFound) {
-            gchar *nextchar = g_utf8_next_char(sWord);
+            const gchar *nextchar = g_utf8_next_char(sWord);
             gchar *firstchar = g_utf8_strup(sWord, nextchar - sWord);
             nextchar = g_utf8_strdown(nextchar, -1);
             casestr = g_strdup_printf("%s%s", firstchar, nextchar);
             g_free(firstchar);
-            g_free(nextchar);
             if (strcmp(casestr, sWord)) {
                 if (oLib[iLib]->Lookup(casestr, iWordIndices))
                     bFound = true;


### PR DESCRIPTION
Fix build with GCC 14 and modern glib: const correctness and deprecated API

- Use 'const gchar*' for result of g_utf8_next_char() to satisfy GCC 14's stricter const rules
- Remove incorrect g_free() on non-allocated pointer from g_utf8_next_char()
- Replace deprecated g_pattern_match_string() with g_pattern_spec_match_string()
