### PR TITLE
README.org: fzf example: preview window make bigger

### DIFF
--- a/README.org
+++ b/README.org
@@ -36,7 +36,7 @@ fzf --prompt="Dict: " \
     --phony \
     --bind "enter:reload(sdcv {q} -n --json | jq '.[].dict' -r)" \
     --preview "sdcv {q} -en --use-dict={}" \
-    --preview-window=wrap \
+    --preview-window=right:70%:wrap \
    < <(echo)
 #+END_SRC
 


### PR DESCRIPTION
Was 50%:50% and by UX we do not need the half of the screen for the dictionary name.

Now:
![image](https://github.com/user-attachments/assets/8ed26f2d-8c55-4e09-b8ca-01eed2a1d0f2)
