### PR TITLE
fix: segmentation fault, non initialized pointers in dictziplib.hpp

### DIFF
--- a/src/dictziplib.hpp
+++ b/src/dictziplib.hpp
@@ -18,10 +18,7 @@ class DictData
 public:
     static const size_t DICT_CACHE_SIZE = 5;
 
-    DictData() {
-        this->chunks = nullptr;
-        this->offsets = nullptr;
-    }
+    DictData() {}
     ~DictData() { close(); }
     bool open(const std::string &filename, int computeCRC);
     void close();
@@ -45,8 +42,8 @@ private:
     int version;
     int chunkLength;
     int chunkCount;
-    int *chunks;
-    unsigned long *offsets; /* Sum-scan of chunks. */
+    int *chunks = nullptr;
+    unsigned long *offsets = nullptr; /* Sum-scan of chunks. */
     std::string origFilename;
     std::string comment;
     unsigned long crc;

--- a/src/dictziplib.hpp
+++ b/src/dictziplib.hpp
@@ -18,7 +18,10 @@ class DictData
 public:
     static const size_t DICT_CACHE_SIZE = 5;
 
-    DictData() {}
+    DictData() {
+        this->chunks = nullptr;
+        this->offsets = nullptr;
+    }
     ~DictData() { close(); }
     bool open(const std::string &filename, int computeCRC);
     void close();


### PR DESCRIPTION
In method void DictData::close() both if (this->chunks) and if (this->offsets) checks can pass even if no allocated memory is assigned to pointers, because both pointers were not initialized to anything, it is UB, so free were called on uninitialized values. Initializing both values to nullptr guarantees that both checks will fail if pointers were not modified, and free is not called.